### PR TITLE
Feature 45: Use local service

### DIFF
--- a/app/components/GoalList/GoalList.js
+++ b/app/components/GoalList/GoalList.js
@@ -9,7 +9,9 @@ class GoalList extends React.PureComponent {
     goals: PropTypes.arrayOf(
       PropTypes.shape(
         {
-          created: PropTypes.number.isRequired,
+          // FIXME: Change to string once done porting all goals
+          // thunks from using client to using storage goals.
+          created: PropTypes.oneOf(PropTypes.string, PropTypes.number).isRequired,
           id: PropTypes.string.isRequired,
           text: PropTypes.string.isRequired,
           status: PropTypes.string.isRequired

--- a/app/models/goals/__tests__/thunks.create-goal.test.js
+++ b/app/models/goals/__tests__/thunks.create-goal.test.js
@@ -3,24 +3,22 @@
 import thunks from 'ss/models/goals/thunks'
 
 describe('goals thunks createGoals', () => {
-  let client, getState, dispatch
+  let getState, goalsService, dispatch
 
   beforeEach(() => {
     getState = jest.fn()
     dispatch = jest.fn()
   })
 
-  describe('client calls successful', () => {
+  describe('goalsService created goal successfully', () => {
     beforeEach(() => {
-      client = {
-        post: jest.fn((_, { body: { text } }) => Promise.resolve(
+      goalsService = {
+        create: jest.fn(({ text }) => Promise.resolve(
           {
-            body: {
-              id: 'some-uuid',
-              text,
-              created: 1234,
-              status: 'not-started'
-            }
+            id: 'some-uuid',
+            text,
+            created: 1234,
+            status: 'not-started'
           }
         ))
       }
@@ -29,7 +27,7 @@ describe('goals thunks createGoals', () => {
     it('should dispatch correct actions', async () => {
       const text = 'some-text'
 
-      await thunks.submitGoal(text)(getState, dispatch, { client })
+      await thunks.submitGoal(text)(getState, dispatch, { goalsService })
 
       expect(dispatch).toHaveBeenCalledTimes(2)
       expect(dispatch.mock.calls[0][0]).toEqual(
@@ -54,20 +52,20 @@ describe('goals thunks createGoals', () => {
     })
   })
 
-  describe('client calls failure', () => {
+  describe('goalsService failed to create goal', () => {
     let error
 
     beforeEach(() => {
       error = new Error('some-error')
-      client = {
-        post: jest.fn((_, { body: { text } }) => Promise.reject(error))
+      goalsService = {
+        create: jest.fn(() => Promise.reject(error))
       }
     })
 
     it('should dispatch correct actions', async () => {
       const text = 'some-text'
 
-      await thunks.submitGoal(text)(getState, dispatch, { client })
+      await thunks.submitGoal(text)(getState, dispatch, { goalsService })
 
       expect(dispatch).toHaveBeenCalledTimes(2)
       expect(dispatch.mock.calls[0][0]).toEqual(

--- a/app/models/goals/thunks.js
+++ b/app/models/goals/thunks.js
@@ -18,32 +18,20 @@ const fetchGoals = () => async (getState, dispatch, { client }) => {
     })
 }
 
-const submitGoal = text => async (getState, dispatch, { client }) => {
+const submitGoal = text => async (getState, dispatch, { goalsService }) => {
   dispatch(goalsActions.submitGoalsRequest(text))
 
-  const options = {
-    body: {
-      text
-    }
-  }
-  client
-    .post('https://small-steps-api.com/v1/goals/', options)
-    .then(response => {
-      const {
-        body: {
-          id,
-          text,
-          created,
-          status
-        }
-      } = response
+  const options = { text }
+  goalsService
+    .create(options)
+    .then(goal => {
       dispatch(
         goalsActions.submitGoalsSuccess(
           {
-            id,
-            text,
-            created,
-            status
+            id: goal.id,
+            text: goal.text,
+            created: goal.created,
+            status: goal.status
           }
         )
       )

--- a/app/services/goals/__tests__/goals-create.test.js
+++ b/app/services/goals/__tests__/goals-create.test.js
@@ -1,0 +1,62 @@
+/* eslint-env jest */
+
+import { uuid } from 'uuidv4'
+
+import goalsService from 'ss/services/goals'
+
+jest.mock('uuidv4', () => ({ uuid: jest.fn() }))
+
+describe('goals service', () => {
+  let storage
+
+  beforeEach(() => {
+    uuid.mockImplementationOnce(() => '735f3627-4449-4be5-8fd8-01e03ad648af')
+    jest.spyOn(global, 'Date').mockImplementationOnce(() => {
+      return {
+        toISOString: () => '2019-12-15T14:21:16.000Z'
+      }
+    })
+    storage = {
+      models: {
+        Goal: {
+          save: goal => Promise.resolve(
+            {
+              created: goal.created,
+              id: goal.id,
+              status: goal.status,
+              text: goal.text
+            }
+          )
+        }
+      }
+    }
+  })
+
+  test('create valid goal', async () => {
+    const options = { text: 'some goals text' }
+
+    const goal = await goalsService(storage).create(options)
+
+    expect(goal.id).toEqual('735f3627-4449-4be5-8fd8-01e03ad648af')
+    expect(goal.created).toEqual('2019-12-15T14:21:16.000Z')
+    expect(goal.status).toEqual('not-started')
+    expect(goal.text).toEqual('some goals text')
+  })
+
+  test('create invalid goal with no text', async () => {
+    const options = { text: undefined }
+
+    const promise = goalsService(storage).create(options)
+
+    await expect(promise).rejects.toThrow(Error('Missing required field: text'))
+  })
+
+  test('storage throws some error', async () => {
+    storage.models.Goal.save = () => Promise.reject(Error('Some storage error'))
+    const options = { text: 'some goals text' }
+
+    const promise = goalsService(storage).create(options)
+
+    await expect(promise).rejects.toThrow(Error('Some storage error'))
+  })
+})

--- a/app/services/goals/__tests__/goals-create.test.js
+++ b/app/services/goals/__tests__/goals-create.test.js
@@ -2,7 +2,7 @@
 
 import { uuid } from 'uuidv4'
 
-import goalsService from 'ss/services/goals'
+import { goalsService } from 'ss/services/goals/goals-service'
 
 jest.mock('uuidv4', () => ({ uuid: jest.fn() }))
 

--- a/app/services/goals/goals-service.js
+++ b/app/services/goals/goals-service.js
@@ -1,6 +1,8 @@
 import { uuid } from 'uuidv4'
 
-const goalsService = storage => {
+import storage from 'ss/services/storage'
+
+export const goalsService = storage => {
   const create = async goal => {
     if (!goal.text) {
       throw Error('Missing required field: text')
@@ -18,4 +20,4 @@ const goalsService = storage => {
   }
 }
 
-export default goalsService
+export default goalsService(storage)

--- a/app/services/goals/goals-service.js
+++ b/app/services/goals/goals-service.js
@@ -1,0 +1,21 @@
+import { uuid } from 'uuidv4'
+
+const goalsService = storage => {
+  const create = async goal => {
+    if (!goal.text) {
+      throw Error('Missing required field: text')
+    }
+
+    goal.created = (new Date()).toISOString()
+    goal.id = uuid()
+    goal.status = 'not-started'
+    await storage.models.Goal.save(goal)
+    return goal
+  }
+
+  return {
+    create
+  }
+}
+
+export default goalsService

--- a/app/services/goals/index.js
+++ b/app/services/goals/index.js
@@ -1,0 +1,3 @@
+import goalsService from './goals-service'
+
+export default goalsService

--- a/app/services/logger/index.js
+++ b/app/services/logger/index.js
@@ -1,0 +1,3 @@
+import logger from './logger'
+
+export default logger

--- a/app/services/logger/logger.js
+++ b/app/services/logger/logger.js
@@ -1,0 +1,7 @@
+const logger = {
+  log: (...args) => {
+    console.log(...args)
+  }
+}
+
+export default logger

--- a/app/services/storage/index.js
+++ b/app/services/storage/index.js
@@ -1,0 +1,3 @@
+import storage from './storage'
+
+export default storage

--- a/app/services/storage/storage.js
+++ b/app/services/storage/storage.js
@@ -1,0 +1,13 @@
+const Goal = {
+  save: async goal => {
+    return Promise.resolve(goal)
+  }
+}
+
+const storage = {
+  models: {
+    Goal
+  }
+}
+
+export default storage

--- a/app/store/__tests__/store.test.js
+++ b/app/store/__tests__/store.test.js
@@ -1,0 +1,60 @@
+/* eslint-env jest */
+
+import client from 'ss/services/client'
+import goalsService from 'ss/services/goals'
+import logger from 'ss/services/logger'
+import store from 'ss/store'
+
+jest.mock('ss/services/client', () => {
+  return { get: jest.fn() }
+})
+
+jest.mock('ss/services/goals', () => {
+  return {
+    models: {
+      Goal: {
+        save: jest.fn()
+      }
+    }
+  }
+})
+
+jest.mock('ss/services/logger', () => {
+  return {
+    log: jest.fn()
+  }
+})
+
+describe('store', () => {
+  test('thunk middleware is installed with goals service', () => {
+    const action = (getState, dispatch, { goalsService }) => {
+      goalsService.models.Goal.save()
+    }
+    const thunkedAction = jest.fn(() => action)
+
+    store.dispatch(thunkedAction())
+
+    expect(goalsService.models.Goal.save).toHaveBeenCalledTimes(1)
+  })
+
+  test('thunk middleware is installed with client service', () => {
+    const action = (getState, dispatch, { client }) => {
+      client.get()
+    }
+    const thunkedAction = jest.fn(() => action)
+
+    store.dispatch(thunkedAction())
+
+    expect(client.get).toHaveBeenCalledTimes(1)
+  })
+
+  test('logger middleware is installed with logger', () => {
+    const action = { type: 'some-action-type' }
+    jest.spyOn(store, 'dispatch')
+
+    store.dispatch(action)
+
+    expect(logger.log).toHaveBeenCalled()
+    expect(store.dispatch.mock.calls).toEqual([[{ type: 'some-action-type' }]])
+  })
+})

--- a/app/store/__tests__/thunk-middleware.test.js
+++ b/app/store/__tests__/thunk-middleware.test.js
@@ -1,0 +1,37 @@
+/* eslint-env jest */
+
+import thunk from 'ss/store/thunk-middleware'
+
+describe('thunk middleware', () => {
+  let services, store, next, action
+
+  beforeEach(() => {
+    services = {}
+    store = { dispatch: jest.fn(), getState: jest.fn() }
+    next = jest.fn(action => action)
+    action = {}
+  })
+
+  test('action is a function', async () => {
+    action = jest.fn()
+
+    await thunk(services)(store)(next)(action)
+
+    expect(next.mock.calls).toEqual([])
+    expect(action.mock.calls).toEqual(
+      [
+        [store.getState, store.dispatch, services]
+      ]
+    )
+  })
+
+  test('action is an object', async () => {
+    action = { type: 'some-action-type' }
+
+    const result = await thunk(services)(store)(next)(action)
+
+    expect(next.mock.calls).toEqual([[action]])
+    expect(result).toEqual(next.mock.results[0].value)
+    expect(result).toEqual(action)
+  })
+})

--- a/app/store/logger-middleware.js
+++ b/app/store/logger-middleware.js
@@ -1,11 +1,11 @@
-const logger = store => next => action => {
+const logger = logger => store => next => action => {
   const prevState = store.getState()
   const nextAction = next(action)
   const nextState = store.getState()
 
-  console.log('prevState', prevState)
-  console.log('action', action)
-  console.log('nextState', nextState)
+  logger.log('prevState', prevState)
+  logger.log('action', action)
+  logger.log('nextState', nextState)
 
   return nextAction
 }

--- a/app/store/store.js
+++ b/app/store/store.js
@@ -1,10 +1,12 @@
 import { applyMiddleware, combineReducers, createStore } from 'redux'
 
 import appReducer from 'ss/models/app/reducer'
-import client from 'ss/services/client'
 import formsReducer from 'ss/models/forms/reducer'
 import goalsReducer from 'ss/models/goals/reducer'
 import tasksReducer from 'ss/models/tasks/reducer'
+import client from 'ss/services/client'
+import goalsService from 'ss/services/goals'
+import loggerService from 'ss/services/logger'
 
 import logger from './logger-middleware'
 import thunk from './thunk-middleware'
@@ -20,8 +22,8 @@ const reducer = combineReducers(
 const store = createStore(
   reducer,
   applyMiddleware(
-    thunk(client),
-    logger
+    thunk({ client, goalsService }),
+    logger(loggerService)
   )
 )
 

--- a/app/store/thunk-middleware.js
+++ b/app/store/thunk-middleware.js
@@ -1,10 +1,10 @@
-const thunk = client => store => next => async action => {
+const thunk = services => store => next => async action => {
   if (typeof action !== 'function') {
     return next(action)
   }
 
   const { getState, dispatch } = store
-  await action(getState, dispatch, { client })
+  await action(getState, dispatch, services)
 }
 
 export default thunk

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "react-native-config": "^0.11.7",
     "react-native-device-info": "^2.3.2",
     "react-redux": "^7.1.1",
-    "redux": "^4.0.4"
+    "redux": "^4.0.4",
+    "uuidv4": "^6.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7045,10 +7045,17 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@^3.3.2:
+uuid@3.3.3, uuid@^3.3.2:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
   integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
+
+uuidv4@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/uuidv4/-/uuidv4-6.0.0.tgz#af64d9d0b6e5cc42675376622dc386f06d7461bb"
+  integrity sha512-KvtCP/4TGL1lU3CviYgWsSiKtJ+vi7FyJ0o+9RIGmJDVw1+O0lM+6pX127t5R6+EHzHOBnzG8zfWUufB4iECRw==
+  dependencies:
+    uuid "3.3.3"
 
 v8-compile-cache@^2.0.3:
   version "2.1.0"


### PR DESCRIPTION
Should solve the preliminary part of the first item in #45 by setting up the goals thunks to use local storage service and goals service instead of mock remote api.